### PR TITLE
ignore line when server returns an EXPIRE_STRING with an empty value.

### DIFF
--- a/dns-domain-expiration-checker.py
+++ b/dns-domain-expiration-checker.py
@@ -98,6 +98,8 @@ def parse_whois_data(whois_data):
 
     for line in whois_data.splitlines():
         if any(expire_string in line for expire_string in EXPIRE_STRINGS):
+            if line.partition(": ")[2] == "":
+                continue
             expiration_date = dateutil.parser.parse(line.partition(": ")[2], ignoretz=True)
 
         if any(registrar_string in line for registrar_string in


### PR DESCRIPTION
When checking my domains, I found that the whois server was returning these lines:
Registry Expiry Date: 2021-02-13T22:31:37Z
Registrar Registration Expiration Date:

The second one, with an empty expiration date, would cause it to throw an error:
Traceback (most recent call last):
  File "dns-domain-expiration-checker.py", line 242, in <module>
    main()
  File "dns-domain-expiration-checker.py", line 227, in main
    expiration_date, registrar = make_whois_query(conf_options["domainname"])
  File "dns-domain-expiration-checker.py", line 88, in make_whois_query
    return(parse_whois_data(whois_data))
  File "dns-domain-expiration-checker.py", line 101, in parse_whois_data
    expiration_date = dateutil.parser.parse(line.partition(": ")[2], ignoretz=True)
  File "/home/joe/local/lib/python2.7/site-packages/dateutil/parser/_parser.py", line 1301, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/joe/local/lib/python2.7/site-packages/dateutil/parser/_parser.py", line 610, in parse
    raise ValueError("String does not contain a date:", timestr)
ValueError: (u'String does not contain a date:', '')

In this pull request, if the date value is empty it moves on to parsing the next line of the whois data.