### PR TITLE
Fix imports and a few logic errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+domains

--- a/dns-domain-expiration-checker.py
+++ b/dns-domain-expiration-checker.py
@@ -35,7 +35,8 @@ EXPIRE_STRINGS = [ "Registry Expiry Date:",
                    "Registrar Registration Expiration Date:",
                    "expire:",
                    "expires:",
-                   "Expiry date"
+                   "Expiry date",
+                   "Expire Date:"
                  ]
 
 REGISTRAR_STRINGS = [

--- a/dns-domain-expiration-checker.py
+++ b/dns-domain-expiration-checker.py
@@ -21,8 +21,13 @@ import smtplib
 import dateutil.parser
 import subprocess
 from datetime import datetime
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEText import MIMEText
+
+if int(sys.version[0]) >= 3:
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+else:
+    from email.MIMEMultipart import MIMEMultipart
+    from email.MIMEText import MIMEText
 
 EXPIRE_STRINGS = [ "Registry Expiry Date:",
                    "Expiration:",
@@ -100,6 +105,7 @@ def parse_whois_data(whois_data):
     registrar = "Unknown"
 
     for line in whois_data.splitlines():
+        line = str(line)
         if any(expire_string in line for expire_string in EXPIRE_STRINGS):
             expiration_date = dateutil.parser.parse(line.partition(": ")[2], ignoretz=True)
 
@@ -122,10 +128,7 @@ def calculate_expiration_days(expire_days, expiration_date):
         print("Unable to calculate the expiration days")
         sys.exit(1)
 
-    if domain_expire.days < expire_days:
-        return domain_expire.days
-    else:
-        return 0
+    return domain_expire.days
 
 
 def check_expired(expiration_days, days_remaining):
@@ -239,7 +242,7 @@ def main():
         # Need to wait between queries to avoid triggering DOS measures like so:
         # Your IP has been restricted due to excessive access, please wait a bit
         time.sleep(conf_options["sleeptime"])
- 
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
1. Imports are broken in Python 3 due to changing of module namespaces:

```
[$] python -V
Python 3.7.6

[$] python dns-domain-expiration-checker.py
Traceback (most recent call last):
  File "dns-domain-expiration-checker.py", line 24, in <module>
    from email.MIMEMultipart import MIMEMultipart
ModuleNotFoundError: No module named 'email.MIMEMultipart' 
```

I have added a condition such that the correct names are used for Python 3 while still working in Python 2.

2. There was a type mismatch in the expiry comparison logic, I have fixed it by casting the correct type (str vs binary) on the variable.

3. The output logic for the application only returns a value for days left to expiry if it is < threshold defined by user, I believe this is a mistake and a number should always be output, as currently it will return 0 when a domain is > threshold which implies a valid domain is expired...